### PR TITLE
Improvements to jut & influx outputs.

### DIFF
--- a/lib/output-influx.js
+++ b/lib/output-influx.js
@@ -42,9 +42,9 @@ InfluxOutput.prototype.toString = function toString()
 
 InfluxOutput.prototype._write = function _write(event, encoding, callback)
 {
-	var point = {};
-	_.assign(point, event);
-	if (point.tags) delete point.tags; // influx client does not like arrays
+	var point = _.pick(event, function(v) { return !_.isObject(v) && !_.isArray(v); });
+	if (event.time)
+		point.time = event.time;
 	if (point.time && typeof point.time !== 'object') point.time = new Date(point.time);
 
 	var self = this;
@@ -61,6 +61,7 @@ InfluxOutput.prototype._write = function _write(event, encoding, callback)
 				else
 				{
 					self.log.error('failure writing a point to influx:');
+					self.log.error(event.name, point);
 					self.log.error(err);
 				}
 				self.errcount = 0;

--- a/lib/output-jut.js
+++ b/lib/output-jut.js
@@ -23,23 +23,29 @@ var JutOutput = module.exports = function JutOutput(opts)
 	this.target = opts.target;
 	this.request = opts.request || require('request');
 
-	this.logger = bole(this.toString());
+	this.log = bole('jut');
+	this.log.info('jut output configured');
 };
 util.inherits(JutOutput, stream.Writable);
 
-JutOutput.prototype.client = null; // client for data sink
-JutOutput.prototype.batch = [];
+JutOutput.prototype.client    = null; // client for data sink
+JutOutput.prototype.batch     = [];
 JutOutput.prototype.batchSize = 1000;
+JutOutput.prototype.lasterror = 0;
+JutOutput.prototype.THROTTLE  = 300000; // 5 minutes
+JutOutput.prototype.log = null;
 
 JutOutput.prototype._write = function _write(event, encoding, callback)
 {
-	var point = { source_type: 'metric', pid: process.pid };
-	_.assign(point, event);
-	if (point.tags) delete point.tags; // influx client does not like arrays
-	if (!point.time)
-		point.time = (new Date()).toISOString();
-	if (typeof point.time !== 'object')
-		point.time = new Date(point.time).toISOString();
+	if (event.name === 'heartbeat') return callback();
+	var point = _.pick(event, function(v) { return !_.isObject(v) && !_.isArray(v); });
+	if (point.metric && !point.value)
+	{
+		point.value = point.metric;
+		delete point.metric;
+	}
+	point.time = (new Date()).toISOString();
+	point.pid = process.pid;
 
 	this.batch.push(point);
 	if (this.batch.length >= this.batchSize)
@@ -65,21 +71,33 @@ JutOutput.prototype.writeBatch = function writeBatch()
 
 	this.request(opts, function(err, response, body)
 	{
-		console.log((response && response.statusCode));
-		console.log(body);
 		if (err)
 		{
-			self.logger.error('failed to write batch; retrying; length=' + writeMe.length);
-			self.logger.error(err);
-			self.batch = writeMe.concat(self.batch);
-			return;
+			// throttle error reporting
+			if (self.lasterror + self.THROTTLE < Date.now())
+			{
+				self.lasterror = Date.now();
+				if (self.errcount > 0)
+					self.log.error(self.errcount + ' error(s) writing points to jut suppressed');
+				else
+				{
+					self.log.error('failed to write batch; retrying; length=' + writeMe.length);
+					self.log.error(err);
+					self.batch = writeMe.concat(self.batch);
+				}
+				self.errcount = 0;
+			}
+			else
+				self.errcount++;
 		}
-
-		self.logger.debug('wrote ' + writeMe.length + ' data points');
+		else
+		{
+			self.log.debug('wrote ' + writeMe.length + ' data points');
+		}
 	});
 };
 
 JutOutput.prototype.toString = function toString()
 {
-	return '[ jut @ ' + this.options.target + ' ]';
+	return '[ jut@' + this.options.target + ' ]';
 };

--- a/test/test-02-influx.js
+++ b/test/test-02-influx.js
@@ -18,10 +18,7 @@ MockClient.prototype.writePoint = function writePoint(n, p, cb)
 
 function writePointFail(n, p, cb)
 {
-	process.nextTick(function()
-	{
-		cb(new Error('oh dear I failed'));
-	});
+	cb(new Error('oh dear I failed'));
 }
 
 describe('influx client', function()
@@ -132,7 +129,8 @@ describe('influx client', function()
 			output.client.must.have.property('name');
 			output.client.name.must.equal('test');
 			output.client.must.have.property('point');
-			output.client.point.must.eql({ name: 'test', value: 4 });
+			output.client.point.name.must.equal('test');
+			output.client.point.value.must.equal(4);
 			done();
 		});
 	});
@@ -149,14 +147,16 @@ describe('influx client', function()
 			count++;
 			if (count === 1)
 				arguments[0].must.equal('failure writing a point to influx:');
-			else if (count === 2)
+			else if (count == 2)
+			{
+				arguments[0].must.equal('test');
+			}
+			else if (count === 3)
 			{
 				arguments[0].must.be.instanceof(Error);
 				arguments[0].message.must.equal('oh dear I failed');
 				done();
 			}
-			else
-				console.log('wat');
 		};
 
 		output.write({ name: 'test', value: 4 }, function() { });
@@ -171,10 +171,10 @@ describe('influx client', function()
 		var spy = sinon.spy(output.log, 'error');
 		output.write({ name: 'test', value: 4 }, function()
 		{
-			spy.calledTwice.must.be.true();
+			spy.calledThrice.must.be.true();
 			output.write({ name: 'test', value: 4 }, function()
 			{
-				spy.calledThrice.must.be.false();
+				spy.callCount.must.be.below(4);
 				output.THROTTLE = 0; // stop throttling
 				output.write({ name: 'test', value: 4 }, function()
 				{

--- a/test/test-02-influx.js
+++ b/test/test-02-influx.js
@@ -18,7 +18,10 @@ MockClient.prototype.writePoint = function writePoint(n, p, cb)
 
 function writePointFail(n, p, cb)
 {
-	cb(new Error('oh dear I failed'));
+	process.nextTick(function()
+	{
+		cb(new Error('oh dear I failed'));
+	});
 }
 
 describe('influx client', function()

--- a/test/test-06-jut.js
+++ b/test/test-06-jut.js
@@ -81,12 +81,13 @@ describe('jut output', function()
 			{
 				var point = opts.body[i];
 				point.must.be.an.object();
-				point.must.have.property('source_type');
-				point.source_type.must.equal('metric');
 				point.must.have.property('pid');
 				point.pid.must.equal(process.pid);
 				point.must.have.property('time');
 				point.time.must.be.a.string();
+				point.must.have.property('value');
+				point.value.must.be.a.number();
+				point.must.not.have.property('metric');
 			}
 
 			output.request = saved;
@@ -97,14 +98,14 @@ describe('jut output', function()
 
 		output.batchSize = 2;
 		output.write({ name: 'metric.one', value: 1 });
-		output.write({ name: 'metric.two', value: 2, host: 'localhost' });
+		output.write({ name: 'metric.two', metric: 2, host: 'localhost' });
 	});
 
 	it('handles write errors by retrying', function(done)
 	{
 		var output = new Output(goodOpts);
 		var saved = Request.post;
-		var spy = sinon.spy(output.logger, 'error');
+		var spy = sinon.spy(output.log, 'error');
 
 		output.request = function(opts, cb)
 		{


### PR DESCRIPTION
The Jut output sink now works & sends data to Jut in the form expected. It also has error log throttling as implemented in the Influx output.

We now strip all objects & tags from any points headed to InfluxDB, so you may feel free to decorate your monitoring events with as many of those as you want. Influx can't cope with them.

This will need a new release before we try to send Jut data on production boxes.