### PR TITLE
Simplify TCP stream handling

### DIFF
--- a/lib/collector.js
+++ b/lib/collector.js
@@ -76,28 +76,10 @@ Collector.prototype.destroy = function destroy(callback)
 Collector.prototype.onConnection = function onConnection(socket)
 {
 	this.log.info('new tcp connection', { socket: socket.address() });
-	var transform;
-	var transformer = function(chunk)
-	{
-		if (transform) return;
 
-		transform = new JSONStream();
-		transform.pipe(this.sink);
-		transform.write(chunk);
-		socket.pipe(transform);
-	}.bind(this);
+	var jsonStream = new JSONStream();
+	socket.pipe(jsonStream).pipe(this.sink);
 
-	socket.on('end', function()
-	{
-		if (transform)
-		{
-			socket.unpipe(transform);
-			transform.unpipe();
-			transform = null;
-		}
-	});
-
-	socket.on('data', transformer);
 	socket.on('close', function onCloseSocket()
 	{
 		this.log.info('tcp connection closing', { socket: socket.address() });


### PR DESCRIPTION
As far as I can tell these two approaches are the same, except the lazy `JSONStream` creation.