### PR TITLE
Upgraded influx module to version 4.0.1 to support influxdb 0.9

### DIFF
--- a/lib/output-influx.js
+++ b/lib/output-influx.js
@@ -45,7 +45,7 @@ InfluxOutput.prototype._write = function _write(event, encoding, callback)
 	if (point.time && typeof point.time !== 'object') point.time = new Date(point.time);
 
 	var self = this;
-	self.client.writePoint(event.name, point, function(err)
+	self.client.writePoint(event.name, point, null, function(err)
 	{
 		if (err)
 		{

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "blanket": "~1.1.7",
     "bole": "~2.0.0",
     "dashdash": "~1.10.0",
-    "influx": "~3.4.0",
+    "influx": "~4.0.1",
     "json-stream": "~1.0.0",
     "lodash": "~3.10.0",
     "numbat-influx": "~0.0.3",

--- a/test/test-02-influx.js
+++ b/test/test-02-influx.js
@@ -9,14 +9,14 @@ var
 ;
 
 function MockClient() {}
-MockClient.prototype.writePoint = function writePoint(n, p, cb)
+MockClient.prototype.writePoint = function writePoint(n, p, t, cb)
 {
 	this.name = n;
 	this.point = p;
 	process.nextTick(cb);
 };
 
-function writePointFail(n, p, cb)
+function writePointFail(n, p, t, cb)
 {
 	process.nextTick(function()
 	{


### PR DESCRIPTION
This addresses #11 by upgrading the influx module to version 4.0.1. 

Though, this might be breaking on pre 0.9 versions of influxdb since the influx client method `writePoint()` used by this module has a [new attribute](https://github.com/node-influx/node-influx#writepoint), `tag`, in the 4.x version which I also compensate for here. Without compensating for this new attribute the collector will throw an exception and not write anything to influxdb.